### PR TITLE
Allow fetchCallback to parse expected error responses

### DIFF
--- a/lib/actionTest.js
+++ b/lib/actionTest.js
@@ -37,7 +37,7 @@ var runErrorTests = function runErrorTests(func, action) {
 };
 
 var actionTestSuite = exports.actionTestSuite = function actionTestSuite(reducer) {
-  var defaultState = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+  var defaultState = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
   return function (_ref) {
     var name = _ref.name;
     var creator = _ref.creator;

--- a/lib/index.js
+++ b/lib/index.js
@@ -120,7 +120,7 @@ function createReducer(defaultState) {
   var actionMap = (0, _ramda.mergeAll)(actionMaps);
 
   return function () {
-    var state = arguments.length <= 0 || arguments[0] === undefined ? defaultState : arguments[0];
+    var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : defaultState;
     var action = arguments[1];
 
     var actionType = getPropOrEmptyString('type', action);
@@ -186,8 +186,8 @@ function reduceReducers() {
  * @returns {Object}              standard action object
  */
 var returnActionResult = exports.returnActionResult = function returnActionResult(actionType) {
-  var payload = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-  var meta = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
+  var payload = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  var meta = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
   return {
     type: actionType,
     payload: orEmptyObject(payload),
@@ -327,9 +327,9 @@ var getPayload = exports.getPayload = (0, _ramda.compose)((0, _ramda.prop)('payl
  * @returns {Object}              standard action object
  */
 var returnErrorResult = exports.returnErrorResult = function returnErrorResult(actionType) {
-  var message = arguments.length <= 1 || arguments[1] === undefined ? 'An error occurred' : arguments[1];
-  var payload = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
-  var meta = arguments.length <= 3 || arguments[3] === undefined ? {} : arguments[3];
+  var message = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'An error occurred';
+  var payload = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+  var meta = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
   return {
     type: actionType,
     error: true,
@@ -532,7 +532,7 @@ var getHeaders = exports.getHeaders = function getHeaders(data) {
 };
 var getRedirect = exports.getRedirect = (0, _ramda.compose)((0, _ramda.objOf)('redirect_to'), getHeaders);
 
-var statusFilter = exports.statusFilter = (0, _ramda.cond)([[isNilOrEmpty, emptyObject], [statusIs(401), getRedirect], [statusWithinRange(200, 300), encodeResponse]]);
+var statusFilter = exports.statusFilter = (0, _ramda.cond)([[isNilOrEmpty, emptyObject], [statusIs(401), getRedirect], [(0, _ramda.either)(statusWithinRange(200, 300), (0, _ramda.has)('value')), encodeResponse]]);
 
 var actionCreatorOrNew = exports.actionCreatorOrNew = (0, _ramda.ifElse)((0, _ramda.is)(Function), _ramda.identity, createAction);
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import {
   converge,
   curry,
   defaultTo,
+  either,
   equals,
   flip,
   gte,
@@ -509,7 +510,7 @@ export const getRedirect = compose(objOf('redirect_to'), getHeaders);
 export const statusFilter = cond([
   [isNilOrEmpty, emptyObject],
   [statusIs(401), getRedirect],
-  [statusWithinRange(200, 300), encodeResponse],
+  [either(statusWithinRange(200, 300), has('value')), encodeResponse],
 ]);
 
 export const actionCreatorOrNew = ifElse(is(Function), identity, createAction);


### PR DESCRIPTION
Currently `fetchCallback`'s `statusFilter` will [ignore any response outside the 200-300 range](https://github.com/CrossChx/cx-redux-utils/blob/master/src/index.js#L512), (except in the case of a 401 where it expects a `redirect_to` prop). I added an additional `cond` case that checks to see if the `fetch` response object contains a `value` prop (indicating a value returned from an error) and returns the parsed response as expected.

e.g. for this `fetch` response:

``` js
{
  headers: {...},
  status: 400,
  statusText: "Bad Request",
  url: "http://quo.local.crosschx.com:3000/api/qportal/user/login",
  value: {
    data: {
      code: "400"
      description: "Incorrect username or password."
    },
    meta: {
      developerMessage: "Incorrect username or password."
    }
  }
}
```

the provided handler receives this payload:

``` js
{
  data: {
    code: "400"
    description: "Incorrect username or password."
  },
  meta: {
    developerMessage: "Incorrect username or password."
  }
}
```
